### PR TITLE
Feature/jest reporter keep state json

### DIFF
--- a/examples/jest/jest.config.js
+++ b/examples/jest/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     "reporters": [
         "default",
-        "<rootDir>/node_modules/kelonio/out/plugin/jestReporter",
+        ["<rootDir>/node_modules/kelonio/out/plugin/jestReporter", {keepState: false}]
     ],
     "transform": {
         "^.+\\.tsx?$": "ts-jest",

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -15,7 +15,16 @@ interface KarmaReporterOptions {
     inferBrowsers?: boolean;
 }
 
+interface JestReporterOptions {
+    keepState: boolean;
+}
 export class JestReporter implements jest.Reporter {
+    options: JestReporterOptions = { keepState: false };
+    constructor(testData?: any, options?: JestReporterOptions) {
+        if (options) {
+            this.options = { ...this.options, ...options };
+        }
+    }
     static initializeKelonio(): void {
         const state = new BenchmarkFileState();
         state.delete();
@@ -42,7 +51,9 @@ export class JestReporter implements jest.Reporter {
         b.data = state.read();
         console.log(`\n${b.report()}`);
 
-        state.delete();
+        if (!this.options.keepState) {
+            state.delete();
+        }
     }
 }
 

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -109,6 +109,33 @@ describe("JestReporter", () => {
             `).trimRight());
             expect(fs.existsSync(STATE_FILE)).toBeFalsy();
         });
+
+        describe("options", () => {
+            it("respects keepState = true", () => {
+                JestReporter.initializeKelonio();
+                const reporter = new JestReporter({}, {keepState: true});
+                const spy = jest.spyOn(console, "log");
+                fs.writeFileSync(STATE_FILE, JSON.stringify({
+                    foo: {
+                        durations: [1, 2, 3],
+                        children: {},
+                    }
+                }));
+                benchmark.events.emit("record", ["bar"], new Measurement([4, 5, 6]));
+
+                reporter.onRunComplete();
+
+                expect(spy.mock.calls[0][0]).toBe(stripIndent(`
+                    ${HEADER}
+                    foo:
+                      2 ms (+/- 1.13161 ms) from 3 iterations
+                    bar:
+                      5 ms (+/- 1.13161 ms) from 3 iterations
+                    ${FOOTER}
+                `).trimRight());
+                expect(fs.existsSync(STATE_FILE)).toBeTruthy();
+            });
+        });
     });
 });
 


### PR DESCRIPTION
Looking to use the generated state `.kelonio.state.json` and upload, parse, and use it later?

I've updated the jest reporter to support this, example is provided but it shows `jest.config.js` with:

```
reporters: ['default', ['<rootDir>/node_modules/kelonio/out/plugin/jestReporter', { keepState: true }]],
```