### PR TITLE
test(jest): rename keepState to keepStateAtEnd

### DIFF
--- a/examples/jest/jest.config.js
+++ b/examples/jest/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     "reporters": [
         "default",
-        "<rootDir>/node_modules/kelonio/out/plugin/jestReporter",
+        ["<rootDir>/node_modules/kelonio/out/plugin/jestReporter", {keepStateAtEnd: false}]
     ],
     "transform": {
         "^.+\\.tsx?$": "ts-jest",

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -15,7 +15,16 @@ interface KarmaReporterOptions {
     inferBrowsers?: boolean;
 }
 
+interface JestReporterOptions {
+    keepStateAtEnd: boolean;
+}
 export class JestReporter implements jest.Reporter {
+    options: JestReporterOptions = { keepStateAtEnd: false };
+    constructor(testData?: any, options?: JestReporterOptions) {
+        if (options) {
+            this.options = { ...this.options, ...options };
+        }
+    }
     static initializeKelonio(): void {
         const state = new BenchmarkFileState();
         state.delete();
@@ -42,7 +51,9 @@ export class JestReporter implements jest.Reporter {
         b.data = state.read();
         console.log(`\n${b.report()}`);
 
-        state.delete();
+        if (!this.options.keepStateAtEnd) {
+            state.delete();
+        }
     }
 }
 

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -109,6 +109,33 @@ describe("JestReporter", () => {
             `).trimRight());
             expect(fs.existsSync(STATE_FILE)).toBeFalsy();
         });
+
+        describe("options", () => {
+            it("respects keepStateAtEnd = true", () => {
+                JestReporter.initializeKelonio();
+                const reporter = new JestReporter({}, {keepStateAtEnd: true});
+                const spy = jest.spyOn(console, "log");
+                fs.writeFileSync(STATE_FILE, JSON.stringify({
+                    foo: {
+                        durations: [1, 2, 3],
+                        children: {},
+                    }
+                }));
+                benchmark.events.emit("record", ["bar"], new Measurement([4, 5, 6]));
+
+                reporter.onRunComplete();
+
+                expect(spy.mock.calls[0][0]).toBe(stripIndent(`
+                    ${HEADER}
+                    foo:
+                      2 ms (+/- 1.13161 ms) from 3 iterations
+                    bar:
+                      5 ms (+/- 1.13161 ms) from 3 iterations
+                    ${FOOTER}
+                `).trimRight());
+                expect(fs.existsSync(STATE_FILE)).toBeTruthy();
+            });
+        });
     });
 });
 


### PR DESCRIPTION
To begin, I'd like to say thank you @mtkennerly for building this tool, it's a great piece of work!

This pull request implements the changes found in https://github.com/mtkennerly/kelonio/pull/1 but with the recommended naming changes from `keepState` to `keepStateAtEnd`. I made a new PR as I didn't have permission to edit the existing PR which has these changes.