### PR TITLE
feat: Add very basic total duration/throughput.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,9 @@ export class Measurement {
      *
      * @param durations - Durations measured, in milliseconds.
      *     The list must not be empty.
+     * @param totalDuration - Duration of the entire measurement, in milliseconds.
      */
-    constructor(public durations: Array<number>) {
+    constructor(public durations: Array<number>, public totalDuration: number) {
         if (durations.length === 0) {
             throw new Error("The list of durations must not be empty");
         }
@@ -167,6 +168,11 @@ export interface BenchmarkData {
         durations: Array<number>,
 
         /**
+         * Total duration of the benchmark, i.e. for throughput.
+         */
+        totalDuration: number;
+
+        /**
          * Nested test data, such as when passing `["A", "B"]` as the
          * description to [[Benchmark.record]].
          */
@@ -196,6 +202,8 @@ export async function measure(fn: () => any, options: Partial<MeasureOptions> = 
     const durations: Array<number> = [];
     let calls: Array<Function> = [];
 
+    const measureStart = hrtime();
+
     for (let i = 0; i < mergedOptions.iterations; i++) {
         calls.push(async () => {
             if (mergedOptions.beforeEach !== undefined) {
@@ -221,7 +229,10 @@ export async function measure(fn: () => any, options: Partial<MeasureOptions> = 
         await Promise.all(calls.map(x => x()));
     }
 
-    const measurement = new Measurement(durations);
+    const [measureSec, measureNano] = hrtime(measureStart);
+    const totalDuration = measureSec * 1e3 + measureNano / 1e6;
+
+    const measurement = new Measurement(durations, totalDuration);
     verifyMeasurement(measurement, mergedOptions);
     return measurement;
 }
@@ -358,18 +369,19 @@ export class Benchmark {
         if ((description.length === 0)) {
             throw new Error("The description must not be empty");
         }
-        this.addBenchmarkDurations(this.data, description, measurement.durations);
+        this.addBenchmarkDurations(this.data, description, measurement.durations, measurement.totalDuration);
     }
 
-    private addBenchmarkDurations(data: BenchmarkData, categories: Array<string>, durations: Array<number>): void {
+    private addBenchmarkDurations(data: BenchmarkData, categories: Array<string>, durations: Array<number>, totalDuration: number): void {
         if (!(categories[0] in data)) {
-            data[categories[0]] = { durations: [], children: {} };
+            data[categories[0]] = { durations: [], children: {}, totalDuration: 0 };
         }
 
         if (categories.length === 1) {
             data[categories[0]].durations = data[categories[0]].durations.concat(durations);
+            data[categories[0]].totalDuration += totalDuration;
         } else {
-            this.addBenchmarkDurations(data[categories[0]].children, categories.slice(1), durations);
+            this.addBenchmarkDurations(data[categories[0]].children, categories.slice(1), durations, totalDuration);
         }
     }
 
@@ -380,11 +392,11 @@ export class Benchmark {
             const showChildren = Object.keys(info.children).length > 0;
             lines.push(`${"  ".repeat(depth)}${description}:`);
             if (showMeasurement) {
-                const measurement = new Measurement(info.durations);
+                const measurement = new Measurement(info.durations, info.totalDuration);
                 const mean = round(measurement.mean);
                 const moe = round(measurement.marginOfError);
                 const iterations = measurement.durations.length;
-                lines.push(`${"  ".repeat(depth + 1)}${mean} ms (+/- ${moe} ms) from ${iterations} iterations`);
+                lines.push(`${"  ".repeat(depth + 1)}${mean} ms (+/- ${moe} ms) from ${iterations} iterations (${round(info.totalDuration)} ms total)`);
             }
             if (showMeasurement && showChildren) {
                 lines.push("");
@@ -404,7 +416,7 @@ export class Benchmark {
         if (lines.length === 0) {
             return "";
         } else {
-            return [HEADER, ...this.reportLevel(this.data, 0), FOOTER].join("\n");
+            return [HEADER, ...lines, FOOTER].join("\n");
         }
     }
 
@@ -413,7 +425,7 @@ export class Benchmark {
         for (const [description, info] of Object.entries(level)) {
             const localDescriptions = [...descriptions, description];
             if (info.durations.length > 0) {
-                const measurement = new Measurement(info.durations);
+                const measurement = new Measurement(info.durations, info.totalDuration);
                 measurement.description = localDescriptions;
                 measurements.push(measurement);
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,8 +211,6 @@ export async function measure(fn: () => any, options: Partial<MeasureOptions> = 
     const durations: Array<number> = [];
     let calls: Array<Function> = [];
 
-    const measureStart = hrtime();
-
     for (let i = 0; i < mergedOptions.iterations; i++) {
         calls.push(async () => {
             if (mergedOptions.beforeEach !== undefined) {
@@ -229,6 +227,8 @@ export async function measure(fn: () => any, options: Partial<MeasureOptions> = 
             }
         });
     }
+
+    const measureStart = hrtime();
 
     if (mergedOptions.serial) {
         for (const call of calls) {

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -3,7 +3,7 @@ import { BenchmarkFileState } from "./etc";
 
 const MOCHA_EVENT_TEST_BEGIN = "test";
 const MOCHA_EVENT_RUN_END = "end";
-type KarmaLoggedRecord = { description: Array<string>, durations: Array<number> };
+type KarmaLoggedRecord = { description: Array<string>, durations: Array<number>, totalDuration: number };
 type Extension = {
     extraReport?: (benchmark: Benchmark) => string | void;
 };
@@ -97,7 +97,7 @@ export class KarmaReporter {
 
     static initializeKelonio(): void {
         benchmark.events.on("record", (description, measurement) => {
-            (<any>window).__karma__.log("kelonio", [JSON.stringify({ description, durations: measurement.durations })]);
+            (<any>window).__karma__.log("kelonio", [JSON.stringify({ description, durations: measurement.durations, totalDuration: measurement.totalDuration })]);
         });
     }
 
@@ -110,7 +110,7 @@ export class KarmaReporter {
             if (type === "kelonio") {
                 const parsed: KarmaLoggedRecord = JSON.parse(log.slice(1, -1));
                 const browserDescription = activeConfig.inferBrowsers ? [browser] : [];
-                b.incorporate([...browserDescription, ...parsed.description], new Measurement(parsed.durations));
+                b.incorporate([...browserDescription, ...parsed.description], new Measurement(parsed.durations, parsed.totalDuration));
             }
         };
 

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -110,7 +110,7 @@ export class KarmaReporter {
             if (type === "kelonio") {
                 const parsed: KarmaLoggedRecord = JSON.parse(log.slice(1, -1));
                 const browserDescription = activeConfig.inferBrowsers ? [browser] : [];
-                b.incorporate([...browserDescription, ...parsed.description], new Measurement(parsed.durations));
+                b.incorporate([...browserDescription, ...parsed.description], new Measurement(parsed.durations, 0));
             }
         };
 

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -110,7 +110,7 @@ export class KarmaReporter {
             if (type === "kelonio") {
                 const parsed: KarmaLoggedRecord = JSON.parse(log.slice(1, -1));
                 const browserDescription = activeConfig.inferBrowsers ? [browser] : [];
-                b.incorporate([...browserDescription, ...parsed.description], new Measurement(parsed.durations, 0));
+                b.incorporate([...browserDescription, ...parsed.description], new Measurement(parsed.durations));
             }
         };
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -209,13 +209,14 @@ describe("Benchmark", () => {
             benchmark.data = {
                 foo: {
                     durations: [1, 2, 3, 4],
+                    totalDuration: 101,
                     children: {},
                 }
             };
             expect(benchmark.report()).toBe(normalize(`
                 - - - - - - - - - - - - - - - - - Performance - - - - - - - - - - - - - - - - -
                 foo:
-                  2.5 ms (+/- 1.26517 ms) from 4 iterations
+                  2.5 ms (+/- 1.26517 ms) from 4 iterations (101 ms total)
                 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
             `));
         });
@@ -224,19 +225,21 @@ describe("Benchmark", () => {
             benchmark.data = {
                 foo: {
                     durations: [1],
+                    totalDuration: 101,
                     children: {},
                 },
                 bar: {
                     durations: [2],
+                    totalDuration: 102,
                     children: {},
                 }
             };
             expect(benchmark.report()).toBe(normalize(`
                 ${HEADER}
                 foo:
-                  1 ms (+/- 0 ms) from 1 iterations
+                  1 ms (+/- 0 ms) from 1 iterations (101 ms total)
                 bar:
-                  2 ms (+/- 0 ms) from 1 iterations
+                  2 ms (+/- 0 ms) from 1 iterations (102 ms total)
                 ${FOOTER}
             `));
         });
@@ -245,9 +248,11 @@ describe("Benchmark", () => {
             benchmark.data = {
                 foo: {
                     durations: [1],
+                    totalDuration: 101,
                     children: {
                         bar: {
                             durations: [2],
+                            totalDuration: 102,
                             children: {},
                         }
                     },
@@ -256,10 +261,10 @@ describe("Benchmark", () => {
             expect(benchmark.report()).toBe(normalize(`
                 ${HEADER}
                 foo:
-                  1 ms (+/- 0 ms) from 1 iterations
+                  1 ms (+/- 0 ms) from 1 iterations (101 ms total)
 
                   bar:
-                    2 ms (+/- 0 ms) from 1 iterations
+                    2 ms (+/- 0 ms) from 1 iterations (102 ms total)
                 ${FOOTER}
             `));
         });
@@ -268,9 +273,11 @@ describe("Benchmark", () => {
             benchmark.data = {
                 foo: {
                     durations: [],
+                    totalDuration: 0,
                     children: {
                         bar: {
                             durations: [2],
+                            totalDuration: 102,
                             children: {},
                         }
                     },
@@ -280,7 +287,7 @@ describe("Benchmark", () => {
                 ${HEADER}
                 foo:
                   bar:
-                    2 ms (+/- 0 ms) from 1 iterations
+                    2 ms (+/- 0 ms) from 1 iterations (102 ms total)
                 ${FOOTER}
             `));
         });
@@ -289,12 +296,12 @@ describe("Benchmark", () => {
     describe("measurements", () => {
         it("converts data with one level", () => {
             benchmark.data = {
-                foo: { durations: [1], children: {} },
-                bar: { durations: [2], children: {} },
+                foo: { durations: [1], totalDuration: 101, children: {} },
+                bar: { durations: [2], totalDuration: 102, children: {} },
             };
             expect(benchmark.measurements).toEqual([
-                (() => { const m = new Measurement([1]); m.description = ["foo"]; return m; })(),
-                (() => { const m = new Measurement([2]); m.description = ["bar"]; return m; })(),
+                (() => { const m = new Measurement([1], 101); m.description = ["foo"]; return m; })(),
+                (() => { const m = new Measurement([2], 102); m.description = ["bar"]; return m; })(),
             ]);
         });
 
@@ -302,15 +309,16 @@ describe("Benchmark", () => {
             benchmark.data = {
                 foo: {
                     durations: [],
+                    totalDuration: 0,
                     children: {
                         bar: {
-                            durations: [1], children: {}
+                            durations: [1], totalDuration: 101, children: {}
                         },
                     }
                 },
             };
             expect(benchmark.measurements).toEqual([
-                (() => { const m = new Measurement([1]); m.description = ["foo", "bar"]; return m; })(),
+                (() => { const m = new Measurement([1], 101); m.description = ["foo", "bar"]; return m; })(),
             ]);
         });
 
@@ -322,8 +330,8 @@ describe("Benchmark", () => {
     describe("find", () => {
         it("can find the fastest by the default field", async () => {
             benchmark.data = {
-                foo: { durations: [1, 2], children: {} },
-                bar: { durations: [1.1, 1.2], children: {} },
+                foo: { durations: [1, 2], totalDuration: 101, children: {} },
+                bar: { durations: [1.1, 1.2], totalDuration: 102, children: {} },
             };
             const result = benchmark.find(Criteria.Fastest);
             expect(result?.description).toEqual(["bar"]);
@@ -332,8 +340,8 @@ describe("Benchmark", () => {
 
         it("can find the fastest by a custom field", async () => {
             benchmark.data = {
-                foo: { durations: [1, 2], children: {} },
-                bar: { durations: [1.1, 1.2], children: {} },
+                foo: { durations: [1, 2], totalDuration: 101, children: {} },
+                bar: { durations: [1.1, 1.2], totalDuration: 102, children: {} },
             };
             const result = benchmark.find(Criteria.Fastest, m => m.min);
             expect(result?.description).toEqual(["foo"]);
@@ -341,8 +349,8 @@ describe("Benchmark", () => {
 
         it("can find the slowest by the default field", async () => {
             benchmark.data = {
-                foo: { durations: [1, 2], children: {} },
-                bar: { durations: [0.1, 0.1, 2.1], children: {} },
+                foo: { durations: [1, 2], totalDuration: 101, children: {} },
+                bar: { durations: [0.1, 0.1, 2.1], totalDuration: 102, children: {} },
             };
             const result = benchmark.find(Criteria.Slowest);
             expect(result?.description).toEqual(["foo"]);
@@ -350,8 +358,8 @@ describe("Benchmark", () => {
 
         it("can find the slowest by a custom field", async () => {
             benchmark.data = {
-                foo: { durations: [1, 2], children: {} },
-                bar: { durations: [0.1, 0.1, 2.1], children: {} },
+                foo: { durations: [1, 2], totalDuration: 101, children: {} },
+                bar: { durations: [0.1, 0.1, 2.1], totalDuration: 102, children: {} },
             };
             const result = benchmark.find(Criteria.Slowest, m => m.max);
             expect(result?.description).toEqual(["bar"]);
@@ -359,7 +367,7 @@ describe("Benchmark", () => {
 
         it("returns the measurement when there is only one", async () => {
             benchmark.data = {
-                foo: { durations: [1, 2], children: {} },
+                foo: { durations: [1, 2], totalDuration: 101, children: {} },
             };
             const result = benchmark.find(Criteria.Fastest);
             expect(result?.description).toEqual(["foo"]);

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -64,7 +64,7 @@ describe("JestReporter", () => {
             expect(spy.mock.calls[0][0]).toBe(stripIndent(`
                 ${HEADER}
                 foo:
-                  2 ms (+/- 1.13161 ms) from 3 iterations
+                  2 ms (+/- 1.13161 ms) from 3 iterations (6 ms total)
                 ${FOOTER}
             `).trimRight());
             expect(fs.existsSync(STATE_FILE)).toBeFalsy();
@@ -86,9 +86,9 @@ describe("JestReporter", () => {
             expect(spy.mock.calls[0][0]).toBe(stripIndent(`
                 ${HEADER}
                 foo:
-                  2 ms (+/- 1.13161 ms) from 3 iterations
+                  2 ms (+/- 1.13161 ms) from 3 iterations (6 ms total)
                 bar:
-                  5 ms (+/- 1.13161 ms) from 3 iterations
+                  5 ms (+/- 1.13161 ms) from 3 iterations (15 ms total)
                 ${FOOTER}
             `).trimRight());
             expect(fs.existsSync(STATE_FILE)).toBeFalsy();
@@ -112,10 +112,12 @@ describe("JestReporter", () => {
                     {
                         foo: {
                             durations: [1, 2, 3],
+                            totalDuration: undefined,
                             children: {},
                         },
                         bar: {
                             durations: [4, 5, 6],
+                            totalDuration: 15,
                             children: {},
                         }
                     }
@@ -139,6 +141,7 @@ describe("JestReporter", () => {
                     {
                         bar: {
                             durations: [4, 5, 6],
+                            totalDuration: 15,
                             children: {},
                         }
                     }
@@ -162,9 +165,9 @@ describe("JestReporter", () => {
                 expect(spy.mock.calls[0][0]).toBe(stripIndent(`
                     ${HEADER}
                     foo:
-                      2 ms (+/- 1.13161 ms) from 3 iterations
+                      2 ms (+/- 1.13161 ms) from 3 iterations (6 ms total)
                     bar:
-                      5 ms (+/- 1.13161 ms) from 3 iterations
+                      5 ms (+/- 1.13161 ms) from 3 iterations (15 ms total)
                     ${FOOTER}
                 `).trimRight());
                 expect(fs.existsSync(STATE_FILE)).toBeTruthy();
@@ -187,9 +190,9 @@ describe("JestReporter", () => {
                 expect(spy.mock.calls[0][0]).toBe(stripIndent(`
                     ${HEADER}
                     foo:
-                      2 ms (+/- 1.13161 ms) from 3 iterations
+                      2 ms (+/- 1.13161 ms) from 3 iterations (6 ms total)
                     bar:
-                      5 ms (+/- 1.13161 ms) from 3 iterations
+                      5 ms (+/- 1.13161 ms) from 3 iterations (15 ms total)
                     ${FOOTER}
                 `).trimRight());
                 expect(fs.existsSync(STATE_FILE)).toBeFalsy();
@@ -212,9 +215,9 @@ describe("JestReporter", () => {
                 expect(spy.mock.calls[0][0]).toBe(stripIndent(`
                     ${HEADER}
                     foo:
-                      2 ms (+/- 1.13161 ms) from 3 iterations
+                      2 ms (+/- 1.13161 ms) from 3 iterations (6 ms total)
                     bar:
-                      5 ms (+/- 1.13161 ms) from 3 iterations
+                      5 ms (+/- 1.13161 ms) from 3 iterations (15 ms total)
                     ${FOOTER}
                 `).trimRight());
             });
@@ -279,7 +282,7 @@ describe("KarmaReporter", () => {
             ${HEADER}
             any:
               foo:
-                2 ms (+/- 1.13161 ms) from 3 iterations
+                2 ms (+/- 1.13161 ms) from 3 iterations (6 ms total)
             ${FOOTER}
         `).trim() + "\n");
     });
@@ -294,7 +297,7 @@ describe("KarmaReporter", () => {
         expect(writer.mock.calls[0][0]).toBe(stripIndent(`
             ${HEADER}
             foo:
-              2 ms (+/- 1.13161 ms) from 3 iterations
+              2 ms (+/- 1.13161 ms) from 3 iterations (6 ms total)
             ${FOOTER}
         `).trim() + "\n");
     });
@@ -334,7 +337,7 @@ describe("MochaReporter", () => {
             A:
               B:
                 foo:
-                  2 ms (+/- 1.13161 ms) from 3 iterations
+                  2 ms (+/- 1.13161 ms) from 3 iterations (6 ms total)
             ${FOOTER}
         `).trimRight());
     });
@@ -350,7 +353,7 @@ describe("MochaReporter", () => {
         expect(spy.mock.calls[0][0]).toBe(stripIndent(`
             ${HEADER}
             foo:
-              2 ms (+/- 1.13161 ms) from 3 iterations
+              2 ms (+/- 1.13161 ms) from 3 iterations (6 ms total)
             ${FOOTER}
         `).trimRight());
     });


### PR DESCRIPTION
Not sure if this is worth merging, but I wanted a very basic throughput calculation, so added a `totalDuration` of each measurement.

My use case is that I'm testing database query behavior, and suspected that a certain setup returned faster/lower per-iteration durations, but at the expense of overall throughput, i.e. actually taking longer to perform the total amount of work, b/c of contention around the connection pool.

(I'm using `serial: false`, which is neat!, so throughput is not just avg duration * # of iterations or even `sum(durations)`.)

Funnily enough, this turned out to _not_ be the case (throughout was actually higher), but I didn't know that w/o seeing the total duration of each `record` call / `measurement`.

Ideally, `report` would format `totalDuration` as flipped to be like a "iterations per second" to get a more real throughput metric, but I haven't gotten to that yet. And maybe only output `totalDuration` / `throughput` when `serial: false` is being used, b/c I imagine it's less useful in `serial: true` mode.

Also disclaimer that I didn't really follow/investigate the nested categories aspect of `addBenchmarkDurations`, so admittedly just added some "looks pretty good?" code. Let me know if it's off.

Otherwise thanks for the tool! Very easy to use. 