### PR TITLE
feat: add parameters for test function and afterEach

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -74,10 +74,33 @@ describe("measure", () => {
         expect(count).toBe(100);
     });
 
+    it("provides result of beforeEach to function", async () => {
+        await measure((value) => { 
+            if (value !== 1) {
+                throw new Error("error");
+            }
+        }, {
+            beforeEach: () => 1 
+        });
+    });
+
     it("supports an afterEach callback", async () => {
         let count = 0;
         await measure(() => { }, { afterEach: () => count++ });
         expect(count).toBe(100);
+    });
+
+    it("provides result of beforeEach and function to afterEach", async () => {
+        await measure(() => {
+            return 2;
+        }, {
+            beforeEach: () => 1,
+            afterEach: (beforeValue, functionValue) => {
+                if (beforeValue !== 1 || functionValue !== 2) {
+                    throw new Error("error");
+                }
+            }
+        });
     });
 });
 


### PR DESCRIPTION
Trying to address issue #17. I've added the parameters to the fn callback and afterEach.
It worked well for me when adding those two tests.
There is a certain potential to misuse this without triggering a TS warning:
```
await measure((a: number) => {});
```
Here we don't have the `beforeEach`at all, but this is not triggering TS to complain.
There may be ways to fix this, but it might complicate things. What do you think?